### PR TITLE
chore: update README with local run notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ mongoimport --jsonArray --db marina --collection reservations --file data/reserv
 - MongoDB Atlas + Railway/Render/Fly.io. Configurer les variables d’env.
 
 ## Identifiants de test
-- Admin : `ADMIN_EMAIL` / `ADMIN_PASSWORD` (créés au boot). 
+- Email : admin@russell-port.tld
+- Mot de passe : admin1234
 
 ## Licence
 MIT
+
+### How to run (local, Windows/VS Code)
+```powershell
+npm install
+copy .env.example .env
+npm run dev


### PR DESCRIPTION
## Objet
Ajout des instructions "How to run" (Windows) et rappel import des données dans le README.

## Changements
- Ajout sections How to run (Windows/VS Code )
- Rappel mongoimport (catways, reservations)
- Identifiants de test

## Tests
- [x] README s'affiche correctement sur GitHub
- [x] Commandes testées en local

## Liens
Closes #1

